### PR TITLE
Feat: implement custom error and default derives for structs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sendgrid_thin"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2021"
 authors = ["OLoKo64 <reinaldorozatoj.11cg1@aleeas.com>"]
 description = "A small unofficial library to send emails using Sendgrid."
@@ -17,9 +17,8 @@ default = ["blocking"]
 blocking = []
 
 [dependencies]
-anyhow = "1.0.69"
 reqwest = { version = "0.11.14", features = ["blocking"] }
-serde = { version = "1.0.155", features = ["derive"] }
+serde = { version = "1.0.156", features = ["derive"] }
 serde_json = "1.0.94"
 
 [dev-dependencies]


### PR DESCRIPTION
# Changes

- Add custom error for lib
- Remove anyhow dependency
- Update dependencies
- Implement some useful traits for `Sendgrid` and `SendgridBuilder`